### PR TITLE
Fix typo in TaxonomyTrait::addTerm

### DIFF
--- a/src/TaxonomyTrait.php
+++ b/src/TaxonomyTrait.php
@@ -24,7 +24,7 @@ trait TaxonomyTrait {
    *  The TermRelation object
    */
   public function addTerm($term_id) {
-    $term = ($term instanceof Term) ? $term_id : Term::findOrFail($term_id);
+    $term = ($term_id instanceof Term) ? $term_id : Term::findOrFail($term_id);
 
     $term_relation = [
       'term_id' => $term->id,

--- a/src/TaxonomyTrait.php
+++ b/src/TaxonomyTrait.php
@@ -35,6 +35,26 @@ trait TaxonomyTrait {
   }
 
   /**
+   * Add an existing term to the inheriting model
+   *
+   * @param $term_id int
+   *  The ID of the term to link
+   *
+   * @return object
+   *  The TermRelation object
+   */
+  public function hasTerm($term_id) {
+    $term = ($term_id instanceof Term) ? $term_id : Term::findOrFail($term_id);
+
+    $term_relation = [
+      'term_id' => $term->id,
+      'vocabulary_id' => $term->vocabulary_id,
+    ];
+
+    return ($this->related()->where('term_id', $term_id)->count()) ? true : false;
+  }
+
+  /**
    * Get all the terms for a given vocabulary that are linked to the current
    * Model.
    *


### PR DESCRIPTION
TaxonomyTrait::addTerm was checking instanceof on $term instead of $term_id